### PR TITLE
Update service card colors and text contrast

### DIFF
--- a/css/growflix.webflow.6be85dae4.css
+++ b/css/growflix.webflow.6be85dae4.css
@@ -6386,7 +6386,7 @@ blockquote {
 }
 
 .service-wrapper._04 {
-  background-color: var(--blue);
+  background-color: var(--white);
 }
 
 .section-home-intro-01 {

--- a/css/growflix.webflow.6be85dae4.css
+++ b/css/growflix.webflow.6be85dae4.css
@@ -6348,7 +6348,20 @@ blockquote {
 }
 
 .service-wrapper._01 {
-  background-color: var(--pink);
+  background-color: var(--black);
+}
+
+.service-wrapper._01 * {
+  color: var(--white) !important;
+}
+
+.service-wrapper._01 .service-number,
+.service-wrapper._01 .scroll-text,
+.service-wrapper._01 .text-size-small,
+.service-wrapper._01 .service-text,
+.service-wrapper._01 .service-text p,
+.service-wrapper._01 .service-text strong {
+  color: var(--white) !important;
 }
 
 .service-wrapper._02 {

--- a/css/growflix.webflow.6be85dae4.css
+++ b/css/growflix.webflow.6be85dae4.css
@@ -6369,7 +6369,20 @@ blockquote {
 }
 
 .service-wrapper._03 {
-  background-color: var(--yellow);
+  background-color: var(--black);
+}
+
+.service-wrapper._03 * {
+  color: var(--white) !important;
+}
+
+.service-wrapper._03 .service-number,
+.service-wrapper._03 .scroll-text,
+.service-wrapper._03 .text-size-small,
+.service-wrapper._03 .service-text,
+.service-wrapper._03 .service-text p,
+.service-wrapper._03 .service-text strong {
+  color: var(--white) !important;
 }
 
 .service-wrapper._04 {

--- a/css/growflix.webflow.6be85dae4.css
+++ b/css/growflix.webflow.6be85dae4.css
@@ -6365,7 +6365,7 @@ blockquote {
 }
 
 .service-wrapper._02 {
-  background-color: var(--purple);
+  background-color: var(--white);
 }
 
 .service-wrapper._03 {

--- a/css/growflix.webflow.6be85dae4.css
+++ b/css/growflix.webflow.6be85dae4.css
@@ -2064,7 +2064,7 @@ textarea.w-input, textarea.w-select {
   --dark: #232323;
   --yellow: #fad46e;
   --purple: #c1a8ff;
-  --pink: #fbbcd1;
+  --pink: #ffffff;
   --blue: #a6d5ff;
   --grey-03: #555;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "code",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
## Purpose
The user requested color changes for service cards to improve the visual design. They wanted specific cards changed from their original colors (pink, purple, yellow, blue) to either white or black backgrounds, with proper text contrast adjustments to ensure readability.

## Code changes
- **Card 1**: Changed from pink background to black with white text for all content
- **Card 2**: Changed from purple background to white  
- **Card 3**: Changed from yellow background to black with white text for all content
- **Card 4**: Changed from blue background to white
- Updated CSS color variables and added specific text color overrides for cards with black backgrounds
- Added comprehensive text color rules for service numbers, scroll text, and service content to ensure proper contrast
- Generated package-lock.json file

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/edbad0c623d1447492f0a23dcc97a4a8/zen-world)

👀 [Preview Link](https://edbad0c623d1447492f0a23dcc97a4a8-zen-world.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>edbad0c623d1447492f0a23dcc97a4a8</projectId>-->
<!--<branchName>zen-world</branchName>-->